### PR TITLE
SEEDSDT-490

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     keepalive_timeout  120;
 
-    client_max_body_size 25M;
+    client_max_body_size 100M;
 
     gzip  on;
 


### PR DESCRIPTION
Allow wordpress/nginx to upload files up to 25mb