### PR TITLE
SEEDSDT-1019 Press and dashboard menu cutoff fix

### DIFF
--- a/ui/src/scss/theme/_carousel.scss
+++ b/ui/src/scss/theme/_carousel.scss
@@ -245,7 +245,7 @@
         margin-left: 12px;
         margin-right: $base-unit;
         position: relative;
-        width: 48% !important;
+        width: 47% !important;
       }
     }
   }
@@ -266,12 +266,15 @@
   // Press grid
   &.press-feed {
     .carousel__slider--vertical {
+      ul{
+        width:$extend;
+      }
       li {
         float: left;
         height: $base-unit * 40;
         padding: $base-unit;
         position: relative;
-        width: 27% !important;
+        width: 33% !important;
       }
     }
   }

--- a/ui/src/scss/theme/_tabbed.scss
+++ b/ui/src/scss/theme/_tabbed.scss
@@ -13,6 +13,7 @@
 
   .item {
     padding: 0 5px;
+    flex: auto;
 
     &.active + .item, &:hover + .item {
       .label {
@@ -100,7 +101,9 @@
       background-repeat: no-repeat;
       background-color: transparent;
       padding-left: calc(4em + 0.75rem);
-      width: 204px;
+      max-width: 204px;
+      min-width: 150px;
+      width: $extend;
       height: 75px;
       margin: 0;
       font-size: 14px;

--- a/ui/src/scss/theme/_tabbed.scss
+++ b/ui/src/scss/theme/_tabbed.scss
@@ -114,6 +114,9 @@
 
 .cross-country-tabs{
   .wp-react-lib.tabbed.posts.container{
+    .item{
+      flex: auto;
+    }
     .label{
         width: auto;
     }


### PR DESCRIPTION
SEEDSDT-1019 Fix cut off content in Press and the tab menus in the main dashboard and cross-country dashboard.